### PR TITLE
Add save_fig option as specified in #30

### DIFF
--- a/cc3dtools/GenomeCompare.py
+++ b/cc3dtools/GenomeCompare.py
@@ -166,7 +166,7 @@ class GenomeCompare:
 
 		pass
 
-	def draw ( self , ordering = None ):
+	def draw ( self , ordering = None , save_fig = None ):
 
 		if ordering is None:
 			ordering = []
@@ -195,7 +195,11 @@ class GenomeCompare:
 			for locus in mutated_loci: 
 				plt.plot(loc, locus.to_float() , 'or')
 
-		plt.show()
+		if save_fig:
+			plt.savefig( save_fig , format='png')
+		else:
+			plt.show()
+		
 		pass
 
 	def get_by_name ( self , name ):

--- a/cc3dtools/Lineage.py
+++ b/cc3dtools/Lineage.py
@@ -94,7 +94,7 @@ class Lineage:
     def next_time( self ):
         return self.sub1.time
 
-    def draw ( self, width ):
+    def draw ( self, width , save_fig = False ):
         final_points = []
         plt.figure()
         self.plot( 0 , self.num_descendants() , width , final_points )
@@ -103,7 +103,12 @@ class Lineage:
         plt.yticks([])
         plt.ylabel( 'Division' )
         plt.title('Tree')
-        plt.show()
+
+        if save_fig:
+            plt.savefig( save_fig , format='png')
+        else:
+            plt.show()        
+
         return final_points
 
     def plot( self , center , generation , width , final_points ):
@@ -373,7 +378,7 @@ class MultiLineage(object):
 
         self.lineages = lineages
 
-    def draw( self , width = 20 ):
+    def draw( self , width = 20 , save_fig = None ):
         """
             draws all lineages in the MultiLineage
             @params:
@@ -384,7 +389,7 @@ class MultiLineage(object):
         to_be_returned = []
 
         for lineage in self.lineages:
-            to_be_returned.extend( lineage['lineage'].draw( 20 ) ) # lineage.draw returns a list of points
+            to_be_returned.extend( lineage['lineage'].draw( 20 , save_fig = save_fig ) ) # lineage.draw returns a list of points
 
         return to_be_returned
 

--- a/cc3dtools/PostProcess.py
+++ b/cc3dtools/PostProcess.py
@@ -35,7 +35,7 @@ def discrete_cmap(N, base_cmap='prism'):
 	return base.from_list(cmap_name, color_list, N+1)
 
 
-def spatial_plot( start_file = None , end_file = None , type_colors = ( 'r', 'b', 'g' ) , format = ( 'id' , 'type' , 'x', 'y', 'z' ) , projection = '2d', hide_numbers = True , plot_stack = None):
+def spatial_plot( start_file = None , end_file = None , type_colors = ( 'r', 'b', 'g' ) , format = ( 'id' , 'type' , 'x', 'y', 'z' ) , projection = '2d', hide_numbers = True , plot_stack = None , save_fig = None):
 	"""
 		displays the positions of the cellids at the time of sampling within a simulation
 	"""
@@ -96,7 +96,10 @@ def spatial_plot( start_file = None , end_file = None , type_colors = ( 'r', 'b'
 			args = plot_stack.pop()
 			plt.plot(*args)
 
-	plt.show()
+	if save_fig:
+		plt.savefig( save_fig , format='png')
+	else:
+		plt.show()
 
 
 class SpacePlot ( object ):
@@ -152,7 +155,7 @@ class SpacePlot ( object ):
 		self.end_file = end_file
 
 
-	def plot_all( self , hide_numbers = True , plot_stack = None ):
+	def plot_all( self , hide_numbers = True , plot_stack = None , save_fig = None ):
 		"""
 			plots all genomes in space according to type_colors and projection 
 		"""
@@ -165,7 +168,8 @@ class SpacePlot ( object ):
 			format = self.format , \
 			projection = self.projection , \
 			hide_numbers = hide_numbers , \
-			plot_stack = plot_stack )
+			plot_stack = plot_stack , \
+			save_fig = save_fig )
 		pass
 
 
@@ -193,6 +197,7 @@ class SpacePlot ( object ):
 		"""
 
 		projection = kwargs.get('projection', self.projection)
+		save_fig = kwargs.get( 'save_fig', None )
 		type_colors = kwargs.get('type_colors', self.type_colors)
 		title = ' Locations of Genomes at time of final sampling lineage depth: ' + str( kwargs.get('depth', 'UNKNOWN') )
 		hide_numbers = kwargs.get( 'hide_numbers' , True )
@@ -287,7 +292,10 @@ class SpacePlot ( object ):
 
 
 
-		plt.show()
+		if save_fig:
+			plt.savefig( save_fig , format='png')
+		else:
+			plt.show()
 
 		pass
 
@@ -659,7 +667,7 @@ class PostProcess( object ):
 		return I, len( clusters[0] ) , len( clusters[1] )
 
 	@staticmethod
-	def plot_frequency_graph( frequency_results , title = '' , plot_stack = None ):
+	def plot_frequency_graph( frequency_results , title = '' , plot_stack = None , save_fig = None ):
 		"""
 			Plots the results of PostProcess.frequency_analyze()
 			@params:
@@ -691,12 +699,16 @@ class PostProcess( object ):
 					args = plot_stack.pop()
 					plt.plot(*args)
 
-			plt.show()
+			if save_fig:
+				plt.savefig( save_fig , format='png')
+			else:
+				plt.show()
+
 
 
 
 	@staticmethod
-	def plot_2D_frequency( frequency_results , title = '' , xlim = None , ylim = None ):
+	def plot_2D_frequency( frequency_results , title = '' , xlim = None , ylim = None , save_fig = None ):
 		"""
 			Plots the results of PostProcess.frequency_analyze_ND()
 			@params:
@@ -728,7 +740,11 @@ class PostProcess( object ):
 			plt.xlabel('cells in cluster 1 (N=' + str( N_1 ) + ')')
 			plt.ylabel('cells in cluster 2 (N=' + str( N_2 ) +')')
 			plt.title('2D Frequency Distribution of Inter-Cluster Mutations '+title)
-			plt.show()
+			
+			if save_fig:
+				plt.savefig( save_fig , format='png')
+			else:
+				plt.show()
 
 
 


### PR DESCRIPTION
Add save_fig option as specified in #30
- If `save_fig` is specified in the plotting commands, we will save instead of plotting to the file `save_fig`
- :exclamation: therefore must specify what the file extension is in `save_fig` itself 
